### PR TITLE
Fix import statement in basic_doctests.rst and basic_unittests.rst

### DIFF
--- a/basic_doctests.rst
+++ b/basic_doctests.rst
@@ -70,9 +70,9 @@ that you have passed 0 tests. 0 tests? We just defined one.
 
 You need to go into your ``__init__.py`` file and put some stuff in there.::
 
-    import doctest
+    import doctst
     __test__ = {
-        'Doctest': doctest
+        'Doctest': doctst
     }
 
 


### PR DESCRIPTION
Fixes #7

Correct the import statement in `basic_doctests.rst` from 'import doctest' to 'import doctst'.

* Update the `__test__` dictionary to use 'doctst' instead of 'doctest'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ericholscher/django-testing-docs/pull/20?shareId=b09a2047-c3a0-43a8-8725-9878fece6053).